### PR TITLE
skipping cleanup flag so travis doesnt wipe book

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: r
 cache: packages
 pandoc_version: 1.19.2.1
 deploy:
+  skip_cleanup: true
   before_script: chmod +x _build.sh && bash _build.sh
   provider: script
   script: chmod +x _deploy.sh && bash _deploy.sh


### PR DESCRIPTION
again refs #20 

I think it solves the deploy issue by preventing travis from [cleaning up untracked files](https://docs.travis-ci.com/user/deployment#uploading-files-and-skip_cleanup).