### PR TITLE
Update 03-setup-pipelines.Rmd

### DIFF
--- a/03-setup-pipelines.Rmd
+++ b/03-setup-pipelines.Rmd
@@ -105,7 +105,7 @@ For downstream purposes, i.e. `cytominer`, you may choose to use only so much of
 We'll also set the SAMPLE_PLATE_ID variable, which is used in the profiling steps when a single plate name is required
 
 ```sh
-mkdir -p scratch/${BATCH_ID}/
+mkdir -p ~/efs/${PROJECT_NAME}/workspace/scratch/${BATCH_ID}/
 
 PLATES=$(readlink -f ~/efs/${PROJECT_NAME}/workspace/scratch/${BATCH_ID}/plates_to_process.txt)
 


### PR DESCRIPTION
Since we know and acknowledge in the handbook that sometimes people do this step out of order (and therefore may not be in the directory the handbook would expect, it's probably best to have this be an abspath